### PR TITLE
SDL2 now uses GitHub to host source files.

### DIFF
--- a/deps/src/sdl2-image/import.conf
+++ b/deps/src/sdl2-image/import.conf
@@ -1,3 +1,3 @@
-type=hg
+type=git
 commit_id=release-2.0.5
-repository_uri=https://hg.libsdl.org/SDL_image
+repository_uri=https://github.com/libsdl-org/SDL_image

--- a/deps/src/sdl2-ttf/import.conf
+++ b/deps/src/sdl2-ttf/import.conf
@@ -1,3 +1,3 @@
-type=hg
+type=git
 commit_id=release-2.0.15
-repository_uri=https://hg.libsdl.org/SDL_ttf
+repository_uri=https://github.com/libsdl-org/SDL_ttf

--- a/deps/src/sdl2/import.conf
+++ b/deps/src/sdl2/import.conf
@@ -1,3 +1,3 @@
-type=hg
+type=git
 commit_id=release-2.0.12
-repository_uri=https://hg.libsdl.org/SDL
+repository_uri=https://github.com/libsdl-org/SDL


### PR DESCRIPTION
As stated, had to change otherwise deps wouldn't pull and compile.