### PR TITLE
Correct wrong constant name to fix RD on P1 not registering

### DIFF
--- a/src/main/lua/io/piulxio/isp-attract.lua
+++ b/src/main/lua/io/piulxio/isp-attract.lua
@@ -29,7 +29,7 @@ local function __process(src, src_prev)
         text = {}
     }
 
-    dest.digital[SCREEN_ATTRACT_DI_SELECT_NEXT] = iop_input_state_is_pushed(IO_LXIO_DI_P1_RD, src, src_prev) or
+    dest.digital[SCREEN_ATTRACT_DI_SELECT_NEXT] = iop_input_state_is_pushed(IO_PIUIOLXIO_DI_P1_RD, src, src_prev) or
         iop_input_state_is_pushed(IO_PIUIOLXIO_DI_P2_RD, src, src_prev) or
         iop_input_state_is_pushed(IO_PIUIOLXIO_DI_P1_RD_MENU, src, src_prev) or
         iop_input_state_is_pushed(IO_PIUIOLXIO_DI_P2_RD_MENU, src, src_prev)

--- a/src/main/lua/io/piulxio/isp-operator.lua
+++ b/src/main/lua/io/piulxio/isp-operator.lua
@@ -29,13 +29,13 @@ local function __process(src, src_prev)
         text = {}
     }
 
-    dest.digital[SCREEN_OPERATOR_DI_SELECT_NEXT] = iop_input_state_is_pushed(IO_LXIO_DI_OP_TEST, src, src_prev)
-    dest.digital[SCREEN_OPERATOR_DI_SELECTED] = iop_input_state_is_pushed(IO_LXIO_DI_OP_SERVICE, src,
+    dest.digital[SCREEN_OPERATOR_DI_SELECT_NEXT] = iop_input_state_is_pushed(IO_PIUIOLXIO_DI_OP_TEST, src, src_prev)
+    dest.digital[SCREEN_OPERATOR_DI_SELECTED] = iop_input_state_is_pushed(IO_PIUIOLXIO_DI_OP_SERVICE, src,
         src_prev)
-    dest.digital[SCREEN_OPERATOR_DI_NOISE_BACK] = iop_input_state_is_pushed(IO_LXIO_DI_OP_TEST, src, src_prev)
-        or iop_input_state_is_pushed(IO_LXIO_DI_OP_SERVICE, src, src_prev)
-    dest.digital[SCREEN_OPERATOR_DI_EXIT_APPLICATION] = iop_input_state_is_held(IO_LXIO_DI_OP_TEST, src, src_prev)
-        and iop_input_state_is_held(IO_LXIO_DI_OP_SERVICE, src, src_prev)
+    dest.digital[SCREEN_OPERATOR_DI_NOISE_BACK] = iop_input_state_is_pushed(IO_PIUIOLXIO_DI_OP_TEST, src, src_prev)
+        or iop_input_state_is_pushed(IO_PIUIOLXIO_DI_OP_SERVICE, src, src_prev)
+    dest.digital[SCREEN_OPERATOR_DI_EXIT_APPLICATION] = iop_input_state_is_held(IO_PIUIOLXIO_DI_OP_TEST, src, src_prev)
+        and iop_input_state_is_held(IO_PIUIOLXIO_DI_OP_SERVICE, src, src_prev)
 
     return dest, out
 end


### PR DESCRIPTION
Not yet tested, but I assume this is the cause of this bug. In the year and a half of using this I actually never managed to notice it i use either the cab buttons or P2side lol so someone else immediately pointed it out to me

Edit: I just realized that the service menu also cant be navigated. It is the exact same issue lol